### PR TITLE
fix error when search does not return 'year'

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -253,7 +253,8 @@ def add_new_wanted():
             plugin.notify(msg=_('no_movie_found'))
             return
         items = [
-            '%s %s' % (movie['titles'][0], ('(%s)' % movie['year']) if movie.get('year', False) else '')
+            '%s %s' % (movie['titles'][0], 
+            	('(%s)' % movie['year']) if movie.get('year', False) else '')
             for movie in movies
         ]
         selected = xbmcgui.Dialog().select(

--- a/addon.py
+++ b/addon.py
@@ -253,7 +253,7 @@ def add_new_wanted():
             plugin.notify(msg=_('no_movie_found'))
             return
         items = [
-            '%s (%s)' % (movie['titles'][0], movie['year'])
+            '%s %s' % (movie['titles'][0], ('(%s)' % movie['year']) if movie.get('year', False) else '')
             for movie in movies
         ]
         selected = xbmcgui.Dialog().select(


### PR DESCRIPTION
Thanks for a great plugin!

When adding a new movie, the search results sometimes do not contain 'year' for every movie returned (for example when searching for 'godfather')
This will cause the plugin to crash. The pull request changes this so that year is only shown when available.
